### PR TITLE
Refactor: `[uint]` to `[uint32]`

### DIFF
--- a/Modules/PSReadLineUtils/Library/Remove-PSReadLineHistoryItem.ps1
+++ b/Modules/PSReadLineUtils/Library/Remove-PSReadLineHistoryItem.ps1
@@ -41,7 +41,7 @@ function Remove-PSReadLineHistoryItem {
         # Specifies the number of items to remove from the end of the history. The default value is 1.
         [Parameter(ParameterSetName = "Count")]
         [Alias("Last", "Amount")]
-        [uint] $Count = 1,
+        [uint32] $Count = 1,
 
         # Removes duplicate items
         [Parameter(ParameterSetName = "Duplicate")]

--- a/Modules/Writer/Library/Write-TypeWriter.ps1
+++ b/Modules/Writer/Library/Write-TypeWriter.ps1
@@ -22,21 +22,21 @@ function Write-TypeWriter {
     
         # Characters per minute
         [Parameter(ParameterSetName = "CPM")]
-        [uint] $CPM = 350,
+        [uint32] $CPM = 350,
     
         # Speed of the typewriter (150ms by default)
         [Parameter(ParameterSetName = "Speed")]
-        [uint] $Speed = 150,
+        [uint32] $Speed = 150,
     
         # The minimum time for a keystroke (default: 10ms)
-        [uint] $MinSpeed = 10,
+        [uint32] $MinSpeed = 10,
     
         # The list of characters to pause at
         [string[]] $PauseAt = @(" ", "`n"),
     
         # The the multiplier to apply when pausing
         [ValidatePattern("[0-9]+")]
-        [uint] $PauseMultiplier = 3
+        [uint32] $PauseMultiplier = 3
     )
 
     begin {


### PR DESCRIPTION
PowerShell 5.1 does not infer `[uint]` as `[UInt32]` like PowerShell 7 does.
(Both correctly infer `[int]` as `[UInt32]`)

To maintain compatibility between the two versions, this commit refactors every instance of `[uint]` with `[uint32]`.

Fixes #2