### PR TITLE
Fix `Test-Connection` command issue

### DIFF
--- a/Scripts/Notify-InternetConnectionRestored.ps1
+++ b/Scripts/Notify-InternetConnectionRestored.ps1
@@ -25,7 +25,7 @@ param (
 # Main loop to continuously check for the internet connection
 while ($True) {
     # Check if the internet connection is restored
-    $Connection = Test-Connection -TargetName $TargetName -Count 1 -Quiet
+    $Connection = Test-Connection -TargetName $TargetName -Count 1
 
     if ($Connection.Status -eq 'Success') {
         # Internet connection is restored. Notify the user and exit the loop


### PR DESCRIPTION
Using the `-Quiet` flag was preventing the script from breaking out of the loop